### PR TITLE
Bugfix/help text and reorder rename args

### DIFF
--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -832,7 +832,7 @@ r,[no]remote     Delete remote branch
 
 cmd_rename() {
 	OPTIONS_SPEC="\
-git flow bugfix rename <new_name> [<new_name>]
+git flow bugfix rename <new_name> [<old_name>]
 
 Rename a given bugfix branch
 --

--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -57,6 +57,7 @@ git flow bugfix rebase
 git flow bugfix checkout
 git flow bugfix pull
 git flow bugfix delete
+git flow bugfix rename
 
 Manage your bugfix branches.
 

--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -832,7 +832,7 @@ r,[no]remote     Delete remote branch
 
 cmd_rename() {
 	OPTIONS_SPEC="\
-git flow bugfix rename <new_name> [<old_name>]
+git flow bugfix rename [<old_name>] <new_name>
 
 Rename a given bugfix branch
 --

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -833,7 +833,7 @@ r,[no]remote     Delete remote branch
 
 cmd_rename() {
 	OPTIONS_SPEC="\
-git flow feature rename <new_name> [<new_name>]
+git flow feature rename <new_name> [<old_name>]
 
 Rename a given feature branch
 --

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -833,7 +833,7 @@ r,[no]remote     Delete remote branch
 
 cmd_rename() {
 	OPTIONS_SPEC="\
-git flow feature rename <new_name> [<old_name>]
+git flow feature rename [<old_name>] <new_name>
 
 Rename a given feature branch
 --

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -57,6 +57,7 @@ git flow feature rebase
 git flow feature checkout
 git flow feature pull
 git flow feature delete
+git flow feature rename
 
 Manage your feature branches.
 

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -735,7 +735,7 @@ r,[no]remote          Delete remote branch
 
 cmd_rename() {
 	OPTIONS_SPEC="\
-git flow hotfix rename <new_name> [<new_name>]
+git flow hotfix rename <new_name> [<old_name>]
 
 Rename a given hotfix branch
 --

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -53,6 +53,9 @@ git flow hotfix start
 git flow hotfix finish
 git flow hotfix publish
 git flow hotfix delete
+git flow hotfix rebase
+git flow hotfix track
+git flow hotfix rename
 
 Manage your hotfix branches.
 

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -735,7 +735,7 @@ r,[no]remote          Delete remote branch
 
 cmd_rename() {
 	OPTIONS_SPEC="\
-git flow hotfix rename <new_name> [<old_name>]
+git flow hotfix rename [<old_name>] <new_name>
 
 Rename a given hotfix branch
 --

--- a/git-flow-release
+++ b/git-flow-release
@@ -417,8 +417,10 @@ usage() {
 git flow release [list]
 git flow release start
 git flow release finish
+git flow release branch
 git flow release publish
 git flow release track
+git flow release rebase
 git flow release delete
 
 Manage your release branches.

--- a/git-flow-support
+++ b/git-flow-support
@@ -50,6 +50,7 @@ usage() {
 		OPTIONS_SPEC="\
 git flow support [list]
 git flow support start
+git flow support rebase
 
 Manage your support branches.
 

--- a/gitflow-common
+++ b/gitflow-common
@@ -609,15 +609,17 @@ gitflow_rename_branch() {
 	# read arguments into global variables
 	if [ -z $1 ]; then
 		NEW_NAME=''
-	else
-		NEW_NAME=$1
-	fi
-
-	if [ -z $2 ]; then
 		NAME=''
 	else
-		NAME=$2
+		if [ -z $2 ]; then
+			NAME=''
+			NEW_NAME=$1
+		else
+			NAME=$1
+			NEW_NAME=$2
+		fi
 	fi
+
 	BRANCH=${PREFIX}${NAME}
 	NEW_BRANCH=${PREFIX}${NEW_NAME}
 


### PR DESCRIPTION
[Originally submitted](https://github.com/petervanderdoes/gitflow-avh/pull/403) against [petervanderdoes/gitflow-avh](https://github.com/petervanderdoes/gitflow-avh/):

> https://github.com/ChrisJStone/gitflow-cjs/commit/c0b4b9673e8fdaf3b250268e002dd4eba145238a and https://github.com/ChrisJStone/gitflow-cjs/commit/d6e43fdb37be64af5a3561f63e36b58913e7bc9a add/revise some help text. I think it's a given that you'll want to pull those in, except maybe if you want to change the printout order or something.
>
> https://github.com/ChrisJStone/gitflow-cjs/commit/cf3885ed0becd10227da2e997b641deee42a1f36 may be debatable. It flips the order of the `rename` sub-subcommand arguments to match git conventions--most compellingly, `git branch --move [<oldbranch>] <newbranch>` (where oldbranch is optional and first). In other cases, "old" isn't optional, but it's still first:
> - `git mv <source> <destination>`
> - `git diff <oldcommit> [<newcommit>]`
> - `git remote rename <old> <new>`
>
> Since `rename` was just introduced in 1.11.0, less than a year ago, it wasn't fully documented, and error messages should point users in the right direction, would you consider this change is a reasonably small disruption?

